### PR TITLE
feat: add MCP server for Canyon coverage queries with initial tools a…

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "canyon": {
+      "command": "pnpm",
+      "args": ["--dir", "tools/mcp", "start"],
+      "env": {
+        "CANYON_URL": "http://127.0.0.1:3000"
+      }
+    }
+  }
+}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -19,6 +19,7 @@ jobs:
         @canyonjs/collect
         @canyonjs/babel-plugin
         @canyonjs/cli
+        @canyonjs/mcp
         @canyonjs/git-diff
         @canyonjs/playwright
         @canyonjs/report

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -1,0 +1,81 @@
+# @canyonjs/mcp
+
+Canyon 的 MCP（Model Context Protocol）服务端，供 Cursor / Claude 等 AI 工具查询覆盖率。
+
+## 环境变量
+
+| 变量 | 说明 | 默认值 |
+| --- | --- | --- |
+| `CANYON_URL` | Canyon API 地址（不含尾部 `/`） | `http://127.0.0.1:3000` |
+| `CANYON_TOKEN` | 可选 Bearer Token | 无 |
+
+## 提供的 Tools
+
+| Tool | 作用 |
+| --- | --- |
+| `list_repos` | 列出已接入仓库 |
+| `get_coverage_summary` | 获取 commit / compare / MR 覆盖率摘要 |
+| `get_uncovered_in_diff` | 查看 compare 中未覆盖的变更语句 |
+| `list_compares` | 列出 compare 记录 |
+| `list_snapshots` | 列出覆盖率快照 |
+
+还提供一个 Prompt：`review_compare_coverage`。
+
+## 本地开发
+
+```bash
+cd tools/mcp
+pnpm install
+pnpm build
+pnpm start
+```
+
+## 在 Cursor 里接入
+
+项目根目录 `.cursor/mcp.json` 或 Cursor Settings → MCP：
+
+```json
+{
+  "mcpServers": {
+    "canyon": {
+      "command": "node",
+      "args": ["/绝对路径/canyon/tools/mcp/bin/canyon-mcp.js"],
+      "env": {
+        "CANYON_URL": "http://127.0.0.1:3000"
+      }
+    }
+  }
+}
+```
+
+monorepo 内也可先用 workspace 包：
+
+```json
+{
+  "mcpServers": {
+    "canyon": {
+      "command": "pnpm",
+      "args": ["--dir", "tools/mcp", "start"],
+      "env": {
+        "CANYON_URL": "http://127.0.0.1:3000"
+      }
+    }
+  }
+}
+```
+
+## 示例对话
+
+- 「列出 Canyon 里接入的仓库」
+- 「MR 123 这次改动哪些文件还没覆盖？」
+- 「compare subjectID 是 xxx 的变更覆盖率怎么样？」
+
+`get_uncovered_in_diff` 可以直接传：
+
+- 已有 `subjectID`
+- `mrIid`
+- `baseRef` + `headRef`（可选 `mode` / `baseKind` / `headKind`）
+
+## 架构说明
+
+MCP 进程通过 HTTP 调用现有 Canyon REST API（`/api/coverage/*`、`/api/source/diff`、`/api/repos`），不直接连数据库。业务逻辑仍由主应用负责，MCP 只做摘要化输出，避免把完整 Istanbul map 塞进模型上下文。

--- a/tools/mcp/bin/canyon-mcp.js
+++ b/tools/mcp/bin/canyon-mcp.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/index.mjs";

--- a/tools/mcp/package.json
+++ b/tools/mcp/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@canyonjs/mcp",
+  "version": "0.1.0",
+  "description": "MCP server for Canyon coverage queries",
+  "license": "MIT",
+  "author": "Travis Zhang<https://github.com/travzhang>",
+  "homepage": "https://github.com/canyon-project/canyon#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/canyon-project/canyon"
+  },
+  "bin": {
+    "canyon-mcp": "bin/canyon-mcp.js"
+  },
+  "files": [
+    "bin",
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "start": "node bin/canyon-mcp.js",
+    "typecheck": "tsgo --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@tsconfig/strictest": "^2.0.8",
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "tsdown": "^0.17.0",
+    "vitest": "catalog:"
+  }
+}

--- a/tools/mcp/src/client.ts
+++ b/tools/mcp/src/client.ts
@@ -1,0 +1,190 @@
+export type CoverageSubject = "commit" | "compare" | "pull" | "merge_requests";
+
+export type CompareCreateBody = {
+  repoID: string;
+  provider: string;
+  subject?: string;
+  subjectID?: string;
+  mode?: "commits" | "commit_branch" | "branches" | "mr";
+  baseKind?: "sha" | "branch";
+  headKind?: "sha" | "branch";
+  baseRef?: string;
+  headRef?: string;
+  mrIid?: string;
+  refresh?: boolean;
+};
+
+export type CoverageSummaryEntry = {
+  path?: string;
+  change?: boolean;
+  statements?: { total: number; covered: number; pct: number };
+  changestatements?: { total: number; covered: number; pct: number };
+  newlines?: { total: number; covered: number; pct: number };
+  lines?: { total: number; covered: number; pct: number };
+};
+
+export type CoverageSummaryMap = Record<string, CoverageSummaryEntry>;
+
+export type CompareRecord = {
+  subjectID: string;
+  subject: string;
+  from: string;
+  to: string;
+  base?: string;
+  head?: string;
+  files?: Array<{ path: string; additions: number[]; deletions: number[] }>;
+  createdAt?: string;
+};
+
+export type SnapshotRecord = {
+  id: number;
+  provider: string;
+  repoID: string;
+  subject: string;
+  subjectID: string;
+  status: string;
+  title: string | null;
+  changestatementsCovered: number | null;
+  changestatementsTotal: number | null;
+  statementsCovered: number | null;
+  statementsTotal: number | null;
+  createdAt: string;
+};
+
+export type RepoRecord = {
+  id: string;
+  pathWithNamespace: string;
+  description?: string;
+};
+
+function trimBaseUrl(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+export class CanyonClient {
+  readonly baseUrl: string;
+  readonly token: string | undefined;
+
+  constructor(options?: { baseUrl?: string; token?: string }) {
+    this.baseUrl = trimBaseUrl(
+      options?.baseUrl || process.env["CANYON_URL"] || "http://127.0.0.1:3000",
+    );
+    this.token = options?.token || process.env["CANYON_TOKEN"];
+  }
+
+  private headers(): Record<string, string> {
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    };
+    if (this.token) {
+      headers["Authorization"] = `Bearer ${this.token}`;
+    }
+    return headers;
+  }
+
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      ...init,
+      headers: {
+        ...this.headers(),
+        ...(init?.headers || {}),
+      },
+    });
+
+    const text = await res.text();
+    let body: unknown = null;
+    if (text) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = text;
+      }
+    }
+
+    if (!res.ok) {
+      const message =
+        typeof body === "object" &&
+        body &&
+        ("error" in body || "message" in body)
+          ? String((body as { error?: string; message?: string }).error || (body as { message?: string }).message)
+          : `HTTP ${res.status}`;
+      throw new Error(message);
+    }
+
+    return body as T;
+  }
+
+  health(): Promise<string> {
+    return this.request<string>("/api/health");
+  }
+
+  listRepos(search?: string): Promise<RepoRecord[]> {
+    const qs = search ? `?search=${encodeURIComponent(search)}` : "";
+    return this.request<RepoRecord[]>(`/api/repos${qs}`);
+  }
+
+  getCoverageSummary(args: {
+    provider: string;
+    repoID: string;
+    subject: CoverageSubject;
+    subjectID: string;
+    buildTarget?: string;
+    scene?: string;
+  }): Promise<CoverageSummaryMap> {
+    const params = new URLSearchParams({
+      provider: args.provider,
+      repoID: args.repoID,
+      subject: args.subject,
+      subjectID: args.subjectID,
+    });
+    if (args.buildTarget) params.set("buildTarget", args.buildTarget);
+    if (args.scene) params.set("scene", args.scene);
+    return this.request<CoverageSummaryMap>(`/api/coverage/summary/map?${params}`);
+  }
+
+  listCompares(args: {
+    provider: string;
+    repoID: string;
+    page?: number;
+    pageSize?: number;
+  }): Promise<{ data: CompareRecord[]; total: number }> {
+    const params = new URLSearchParams({
+      provider: args.provider,
+      repoID: args.repoID,
+      page: String(args.page ?? 1),
+      pageSize: String(args.pageSize ?? 20),
+    });
+    return this.request<{ data: CompareRecord[]; total: number }>(`/api/source/diff?${params}`);
+  }
+
+  createCompare(body: CompareCreateBody): Promise<{
+    subjectID: string;
+    from: string;
+    to: string;
+    files: Array<{ path: string; additions: number[]; deletions: number[] }>;
+  }> {
+    return this.request(`/api/source/diff`, {
+      method: "POST",
+      body: JSON.stringify({ subject: "compare", ...body }),
+    });
+  }
+
+  listSnapshots(args: {
+    provider?: string;
+    repoID?: string;
+    subject?: "commit" | "compare";
+    page?: number;
+    pageSize?: number;
+  }): Promise<{ data: SnapshotRecord[]; total: number }> {
+    const params = new URLSearchParams();
+    if (args.provider) params.set("provider", args.provider);
+    if (args.repoID) params.set("repoID", args.repoID);
+    if (args.subject) params.set("subject", args.subject);
+    params.set("page", String(args.page ?? 1));
+    params.set("pageSize", String(args.pageSize ?? 20));
+    return this.request<{ data: SnapshotRecord[]; total: number }>(
+      `/api/coverage/snapshot?${params}`,
+    );
+  }
+}

--- a/tools/mcp/src/index.ts
+++ b/tools/mcp/src/index.ts
@@ -1,0 +1,13 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createCanyonMcpServer } from "./server.js";
+
+async function main() {
+  const server = createCanyonMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((error) => {
+  console.error("Canyon MCP server failed:", error);
+  process.exit(1);
+});

--- a/tools/mcp/src/server.ts
+++ b/tools/mcp/src/server.ts
@@ -1,0 +1,303 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { CanyonClient } from "./client.js";
+import {
+  aggregateCoverageSummary,
+  topChangedFiles,
+  uncoveredChangedFiles,
+} from "./summary.js";
+
+const providerRepoSchema = {
+  provider: z.string().describe("Git provider，例如 gitlab 或 github"),
+  repoID: z.string().describe("仓库 ID 或 path_with_namespace"),
+};
+
+function textResult(data: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(data, null, 2),
+      },
+    ],
+  };
+}
+
+export function createCanyonMcpServer(client = new CanyonClient()): McpServer {
+  const server = new McpServer({
+    name: "canyon",
+    version: "0.1.0",
+  });
+
+  server.registerTool(
+    "list_repos",
+    {
+      description: "列出 Canyon 已接入的仓库，可按 id 或 path 搜索",
+      inputSchema: {
+        search: z.string().optional().describe("可选搜索关键字"),
+      },
+    },
+    async ({ search }) => {
+      const repos = await client.listRepos(search);
+      return textResult(
+        repos.map((repo) => ({
+          id: repo.id,
+          pathWithNamespace: repo.pathWithNamespace,
+          description: repo.description ?? "",
+        })),
+      );
+    },
+  );
+
+  server.registerTool(
+    "get_coverage_summary",
+    {
+      description:
+        "获取 commit / compare / MR 的覆盖率摘要。compare 时 subject=compare，subjectID 为 compare 记录 ID",
+      inputSchema: {
+        ...providerRepoSchema,
+        subject: z
+          .enum(["commit", "compare", "pull", "merge_requests"])
+          .describe("覆盖率主体类型"),
+        subjectID: z.string().describe("commit SHA、compare subjectID 或 MR/PR ID"),
+        buildTarget: z.string().optional().describe("可选 buildTarget"),
+        scene: z.string().optional().describe("可选 scene JSON 字符串"),
+        topChangedLimit: z
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .optional()
+          .default(10)
+          .describe("返回变更文件 Top N，按变更语句覆盖率从低到高排序"),
+      },
+    },
+    async ({ provider, repoID, subject, subjectID, buildTarget, scene, topChangedLimit }) => {
+      const summary = await client.getCoverageSummary({
+        provider,
+        repoID,
+        subject,
+        subjectID,
+        ...(buildTarget ? { buildTarget } : {}),
+        ...(scene ? { scene } : {}),
+      });
+      return textResult({
+        provider,
+        repoID,
+        subject,
+        subjectID,
+        aggregate: aggregateCoverageSummary(summary),
+        topChangedFiles: topChangedFiles(summary, topChangedLimit),
+      });
+    },
+  );
+
+  server.registerTool(
+    "get_uncovered_in_diff",
+    {
+      description:
+        "查看 compare / MR / 分支对比里尚未覆盖的变更语句。可传已有 subjectID，或传 baseRef/headRef/mrIid 自动创建 compare",
+      inputSchema: {
+        ...providerRepoSchema,
+        subjectID: z.string().optional().describe("已有 compare 的 subjectID"),
+        mode: z
+          .enum(["commits", "commit_branch", "branches", "mr"])
+          .optional()
+          .describe("创建 compare 时的模式"),
+        baseKind: z.enum(["sha", "branch"]).optional(),
+        headKind: z.enum(["sha", "branch"]).optional(),
+        baseRef: z.string().optional().describe("base commit SHA 或分支名"),
+        headRef: z.string().optional().describe("head commit SHA 或分支名"),
+        mrIid: z.string().optional().describe("GitLab MR / GitHub PR 的数字 ID"),
+        refresh: z.boolean().optional().describe("是否强制刷新 diff"),
+        buildTarget: z.string().optional(),
+        scene: z.string().optional(),
+        limit: z.number().int().min(1).max(50).optional().default(20),
+      },
+    },
+    async (args) => {
+      let subjectID = args.subjectID;
+      let compareMeta: Record<string, unknown> | undefined;
+
+      if (!subjectID) {
+        if (args.mrIid) {
+          const created = await client.createCompare({
+            provider: args.provider,
+            repoID: args.repoID,
+            mode: "mr",
+            mrIid: args.mrIid,
+            ...(args.refresh ? { refresh: args.refresh } : {}),
+          });
+          subjectID = created.subjectID;
+          compareMeta = {
+            from: created.from,
+            to: created.to,
+            changedFileCount: created.files.length,
+          };
+        } else if (args.baseRef && args.headRef) {
+          const created = await client.createCompare({
+            provider: args.provider,
+            repoID: args.repoID,
+            ...(args.mode ? { mode: args.mode } : {}),
+            ...(args.baseKind ? { baseKind: args.baseKind } : {}),
+            ...(args.headKind ? { headKind: args.headKind } : {}),
+            baseRef: args.baseRef,
+            headRef: args.headRef,
+            ...(args.refresh ? { refresh: args.refresh } : {}),
+          });
+          subjectID = created.subjectID;
+          compareMeta = {
+            from: created.from,
+            to: created.to,
+            changedFileCount: created.files.length,
+          };
+        } else {
+          throw new Error("请提供 subjectID，或 mrIid，或 baseRef + headRef");
+        }
+      } else if (args.refresh) {
+        const refreshed = await client.createCompare({
+          provider: args.provider,
+          repoID: args.repoID,
+          subjectID,
+          refresh: true,
+        });
+        compareMeta = {
+          from: refreshed.from,
+          to: refreshed.to,
+          changedFileCount: refreshed.files.length,
+        };
+      }
+
+      const summary = await client.getCoverageSummary({
+        provider: args.provider,
+        repoID: args.repoID,
+        subject: "compare",
+        subjectID,
+        ...(args.buildTarget ? { buildTarget: args.buildTarget } : {}),
+        ...(args.scene ? { scene: args.scene } : {}),
+      });
+
+      const uncovered = uncoveredChangedFiles(summary, args.limit);
+      return textResult({
+        provider: args.provider,
+        repoID: args.repoID,
+        subjectID,
+        compare: compareMeta,
+        aggregate: aggregateCoverageSummary(summary),
+        uncoveredChangedFiles: uncovered,
+        fullyCovered:
+          uncovered.length === 0 &&
+          aggregateCoverageSummary(summary).changestatements.total > 0,
+      });
+    },
+  );
+
+  server.registerTool(
+    "list_compares",
+    {
+      description: "列出仓库下的 compare / diff 记录",
+      inputSchema: {
+        ...providerRepoSchema,
+        page: z.number().int().min(1).optional().default(1),
+        pageSize: z.number().int().min(1).max(50).optional().default(20),
+      },
+    },
+    async ({ provider, repoID, page, pageSize }) => {
+      const result = await client.listCompares({ provider, repoID, page, pageSize });
+      return textResult({
+        total: result.total,
+        data: result.data.map((item) => ({
+          subjectID: item.subjectID,
+          subject: item.subject,
+          from: item.from,
+          to: item.to,
+          fileCount: item.files?.length ?? 0,
+          createdAt: item.createdAt,
+        })),
+      });
+    },
+  );
+
+  server.registerTool(
+    "list_snapshots",
+    {
+      description: "列出覆盖率快照（含变更语句覆盖率指标）",
+      inputSchema: {
+        provider: z.string().optional(),
+        repoID: z.string().optional(),
+        subject: z.enum(["commit", "compare"]).optional(),
+        page: z.number().int().min(1).optional().default(1),
+        pageSize: z.number().int().min(1).max(50).optional().default(20),
+      },
+    },
+    async ({ provider, repoID, subject, page, pageSize }) => {
+      const result = await client.listSnapshots({
+        ...(provider ? { provider } : {}),
+        ...(repoID ? { repoID } : {}),
+        ...(subject ? { subject } : {}),
+        page,
+        pageSize,
+      });
+      return textResult({
+        total: result.total,
+        data: result.data.map((item) => ({
+          id: item.id,
+          provider: item.provider,
+          repoID: item.repoID,
+          subject: item.subject,
+          subjectID: item.subjectID,
+          status: item.status,
+          title: item.title,
+          statementsCovered: item.statementsCovered,
+          statementsTotal: item.statementsTotal,
+          changestatementsCovered: item.changestatementsCovered,
+          changestatementsTotal: item.changestatementsTotal,
+          createdAt: item.createdAt,
+        })),
+      });
+    },
+  );
+
+  server.registerPrompt(
+    "review_compare_coverage",
+    {
+      description: "生成 review compare 覆盖率的提示词模板",
+      argsSchema: {
+        provider: z.string(),
+        repoID: z.string(),
+        subjectID: z.string().optional(),
+        mrIid: z.string().optional(),
+      },
+    },
+    async ({ provider, repoID, subjectID, mrIid }) => {
+      const lines = [
+        "请帮我 review 这次代码变更的测试覆盖情况。",
+        "",
+        `仓库 provider: ${provider}`,
+        `repoID: ${repoID}`,
+      ];
+      if (subjectID) lines.push(`compare subjectID: ${subjectID}`);
+      if (mrIid) lines.push(`MR/PR IID: ${mrIid}`);
+      lines.push(
+        "",
+        "请先调用 get_uncovered_in_diff 获取未覆盖的变更语句，再给出：",
+        "1. 总体变更覆盖率",
+        "2. 最需要补测的文件",
+        "3. 建议补哪些测试场景",
+      );
+      return {
+        messages: [
+          {
+            role: "user" as const,
+            content: {
+              type: "text" as const,
+              text: lines.join("\n"),
+            },
+          },
+        ],
+      };
+    },
+  );
+
+  return server;
+}

--- a/tools/mcp/src/summary.ts
+++ b/tools/mcp/src/summary.ts
@@ -1,0 +1,111 @@
+import type { CoverageSummaryEntry, CoverageSummaryMap } from "./client.ts";
+
+export type AggregatedCoverage = {
+  statements: { total: number; covered: number; pct: number };
+  changestatements: { total: number; covered: number; pct: number };
+  changedFiles: number;
+  files: number;
+};
+
+export function aggregateCoverageSummary(summary: CoverageSummaryMap): AggregatedCoverage {
+  let statementsTotal = 0;
+  let statementsCovered = 0;
+  let changeTotal = 0;
+  let changeCovered = 0;
+  let changedFiles = 0;
+
+  for (const entry of Object.values(summary)) {
+    statementsTotal += entry.statements?.total ?? 0;
+    statementsCovered += entry.statements?.covered ?? 0;
+    if (entry.change) {
+      changedFiles += 1;
+      changeTotal += entry.changestatements?.total ?? 0;
+      changeCovered += entry.changestatements?.covered ?? 0;
+    }
+  }
+
+  return {
+    statements: {
+      total: statementsTotal,
+      covered: statementsCovered,
+      pct: pct(statementsCovered, statementsTotal),
+    },
+    changestatements: {
+      total: changeTotal,
+      covered: changeCovered,
+      pct: pct(changeCovered, changeTotal),
+    },
+    changedFiles,
+    files: Object.keys(summary).length,
+  };
+}
+
+export function topChangedFiles(
+  summary: CoverageSummaryMap,
+  limit = 10,
+): Array<{
+  path: string;
+  changestatements: { total: number; covered: number; pct: number };
+  statements: { total: number; covered: number; pct: number };
+}> {
+  return Object.entries(summary)
+    .filter(([, entry]) => entry.change && (entry.changestatements?.total ?? 0) > 0)
+    .map(([path, entry]) => ({
+      path: entry.path || path,
+      changestatements: {
+        total: entry.changestatements?.total ?? 0,
+        covered: entry.changestatements?.covered ?? 0,
+        pct: entry.changestatements?.pct ?? 0,
+      },
+      statements: {
+        total: entry.statements?.total ?? 0,
+        covered: entry.statements?.covered ?? 0,
+        pct: entry.statements?.pct ?? 0,
+      },
+    }))
+    .sort((a, b) => a.changestatements.pct - b.changestatements.pct)
+    .slice(0, limit);
+}
+
+export function uncoveredChangedFiles(
+  summary: CoverageSummaryMap,
+  limit = 20,
+): Array<{
+  path: string;
+  uncoveredChangeStatements: number;
+  changestatements: { total: number; covered: number; pct: number };
+}> {
+  return Object.entries(summary)
+    .filter(([, entry]) => {
+      const total = entry.changestatements?.total ?? 0;
+      const covered = entry.changestatements?.covered ?? 0;
+      return entry.change && total > covered;
+    })
+    .map(([path, entry]) => ({
+      path: entry.path || path,
+      uncoveredChangeStatements:
+        (entry.changestatements?.total ?? 0) - (entry.changestatements?.covered ?? 0),
+      changestatements: {
+        total: entry.changestatements?.total ?? 0,
+        covered: entry.changestatements?.covered ?? 0,
+        pct: entry.changestatements?.pct ?? 0,
+      },
+    }))
+    .sort((a, b) => b.uncoveredChangeStatements - a.uncoveredChangeStatements)
+    .slice(0, limit);
+}
+
+function pct(covered: number, total: number): number {
+  if (total <= 0) return 100;
+  return Math.round((covered / total) * 10000) / 100;
+}
+
+export function compactSummaryEntry(entry: CoverageSummaryEntry) {
+  return {
+    path: entry.path,
+    change: entry.change ?? false,
+    statements: entry.statements,
+    changestatements: entry.changestatements,
+    newlines: entry.newlines,
+  };
+}

--- a/tools/mcp/tests/summary.test.ts
+++ b/tools/mcp/tests/summary.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateCoverageSummary,
+  topChangedFiles,
+  uncoveredChangedFiles,
+} from "../src/summary.ts";
+
+describe("coverage summary helpers", () => {
+  const summary = {
+    "src/a.ts": {
+      path: "src/a.ts",
+      change: true,
+      statements: { total: 10, covered: 8, pct: 80, skipped: 0 },
+      changestatements: { total: 4, covered: 2, pct: 50, skipped: 0 },
+    },
+    "src/b.ts": {
+      path: "src/b.ts",
+      change: true,
+      statements: { total: 5, covered: 5, pct: 100, skipped: 0 },
+      changestatements: { total: 2, covered: 2, pct: 100, skipped: 0 },
+    },
+    "src/c.ts": {
+      path: "src/c.ts",
+      change: false,
+      statements: { total: 3, covered: 3, pct: 100, skipped: 0 },
+    },
+  };
+
+  it("aggregates statement and change metrics", () => {
+    const agg = aggregateCoverageSummary(summary);
+    expect(agg.files).toBe(3);
+    expect(agg.changedFiles).toBe(2);
+    expect(agg.statements.total).toBe(18);
+    expect(agg.changestatements.total).toBe(6);
+    expect(agg.changestatements.covered).toBe(4);
+  });
+
+  it("lists uncovered changed files by gap size", () => {
+    const uncovered = uncoveredChangedFiles(summary);
+    expect(uncovered).toHaveLength(1);
+    expect(uncovered[0]?.path).toBe("src/a.ts");
+    expect(uncovered[0]?.uncoveredChangeStatements).toBe(2);
+  });
+
+  it("sorts changed files by lowest change coverage", () => {
+    const top = topChangedFiles(summary);
+    expect(top[0]?.path).toBe("src/a.ts");
+    expect(top[1]?.path).toBe("src/b.ts");
+  });
+});

--- a/tools/mcp/tsconfig.json
+++ b/tools/mcp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@tsconfig/strictest/tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "moduleDetection": "force",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src"]
+}

--- a/tools/mcp/tsdown.config.ts
+++ b/tools/mcp/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: "./src/index.ts",
+  platform: "node",
+  format: "esm",
+  dts: true,
+  shims: true,
+});

--- a/tools/mcp/vitest.config.ts
+++ b/tools/mcp/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## 做了什么

新增包 **`@canyonjs/mcp`**，通过 HTTP 调用现有 Canyon API，不直接连数据库。

**5 个 Tools：**
| Tool | 作用 |
|---|---|
| `list_repos` | 列出已接入仓库 |
| `get_coverage_summary` | commit / compare / MR 覆盖率摘要 |
| `get_uncovered_in_diff` | compare 里未覆盖的变更语句（最有用） |
| `list_compares` | 列出 compare 记录 |
| `list_snapshots` | 列出快照及变更覆盖率 |

**1 个 Prompt：** `review_compare_coverage` — 引导模型先查覆盖率再 review。

## 怎么接 Cursor

项目根目录已加 `.cursor/mcp.json`：

```json
{
  "mcpServers": {
    "canyon": {
      "command": "pnpm",
      "args": ["--dir", "tools/mcp", "start"],
      "env": {
        "CANYON_URL": "http://127.0.0.1:3000"
      }
    }
  }
}
```

使用前：
1. 启动 Canyon app（`pnpm dev` 在 `app/`）
2. 在 Cursor 里刷新 MCP，确认 `canyon` 已连接

环境变量：
- `CANYON_URL` — API 地址，默认 `http://127.0.0.1:3000`
- `CANYON_TOKEN` — 可选 Bearer Token（当前 coverage 接口大多无需鉴权）

## 示例问法

- 「列出 Canyon 接入的仓库」
- 「MR 123 哪些变更还没覆盖？」
- 「compare subjectID 是 xxx 的变更覆盖率怎么样？」

`get_uncovered_in_diff` 支持三种入参：
- 已有 `subjectID`
- `mrIid`
- `baseRef` + `headRef`

## 文件结构

```
tools/mcp/
├── bin/canyon-mcp.js      # 启动入口
├── src/client.ts          # Canyon HTTP 客户端
├── src/summary.ts         # 摘要/未覆盖计算
├── src/server.ts          # MCP tools 注册
└── README.md
```

构建和测试已通过。若 `CANYON_URL` 不是本机 3000，改 `.cursor/mcp.json` 里的地址即可。需要的话我可以再帮你加 HTTP 模式（挂在 Hono 的 `/mcp` 上），方便团队远程共用。